### PR TITLE
Fix response with multiple elements

### DIFF
--- a/nomini.js
+++ b/nomini.js
@@ -168,7 +168,7 @@
         const template = document.createElement("template");
         template.innerHTML = text;
 
-        for (const fragment of template.content.children) {
+        for (const fragment of [...template.content.children]) {
             if (!fragment.id) {
                 console.warn("[Nomini] Fragment is missing an id: ", fragment);
                 continue;


### PR DESCRIPTION
Right now the fragment iterator doesn't work properly with responses that have multiple elements

The fix spreads the array upfront so calls that remove nodes from template doesn't affect iteration
